### PR TITLE
Removed temp directory

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,27 +54,10 @@ define sslcertificate($password, $location, $thumbprint, $root_store = 'LocalMac
   validate_re($location, '^(.)+$',"Must pass location to ${module_name}[${title}]")
   validate_re($thumbprint, '^(.)+$', "Must pass a certificate thumbprint to ${module_name}[${title}]")
 
-  ensure_resource('file', 'C:\temp', { ensure => directory })
-
-  file { "inspect-${name}-certificate.ps1" :
-    ensure  => present,
-    path    => "C:\\temp\\inspect-${name}.ps1",
-    content => template('sslcertificate/inspect.ps1.erb'),
-    require => File['C:\temp']
-  }
-
-  file { "import-${name}-certificate.ps1" :
-    ensure  => present,
-    path    => "C:\\temp\\import-${name}.ps1",
-    content => template('sslcertificate/import.ps1.erb'),
-    require => File['C:\temp']
-  }
-
   exec { "Install-${name}-SSLCert":
     provider  => powershell,
-    command   => "c:\\temp\\import-${name}.ps1",
-    onlyif    => "c:\\temp\\inspect-${name}.ps1",
+    command   => template("sslcertificate/import.ps1.erb"),
+    onlyif    => template("sslcertificate/inspect.ps1.erb"),
     logoutput => true,
-    require   => [ File["inspect-${name}-certificate.ps1"], File["import-${name}-certificate.ps1"] ],
   }
 }

--- a/spec/defines/sslcertificate_spec.rb
+++ b/spec/defines/sslcertificate_spec.rb
@@ -13,25 +13,11 @@ describe 'sslcertificate', :type => :define do
     } }
 
     it { should contain_exec('Install-testCert-SSLCert').with(
-      'command'  => 'c:\temp\import-testCert.ps1',
-      'onlyif'   => 'c:\temp\inspect-testCert.ps1',
+      'command'  => 'template("sslcertificate/import.ps1.erb")',
+      'onlyif'   => 'template("sslcertificate/inspect.ps1.erb")',
       'provider' => 'powershell'
     )}
 
-    it { should contain_file('import-testCert-certificate.ps1').with(
-      'ensure'  => 'present',
-      'path'    => 'C:\\temp\\import-testCert.ps1',
-      'require' => 'File[C:\temp]'
-    )}
-
-    it { should contain_file('import-testCert-certificate.ps1').with_content(/store.Add/) }
-
-    it { should contain_file('inspect-testCert-certificate.ps1').with(
-      'ensure'  => 'present',
-      'path'    => 'C:\\temp\\inspect-testCert.ps1',
-      'require' => 'File[C:\temp]'
-    )}
-    it { should contain_file('inspect-testCert-certificate.ps1').with_content(/\$installedCert in \$installedCerts/) }
 
   end
 

--- a/spec/defines/sslcertificate_spec.rb
+++ b/spec/defines/sslcertificate_spec.rb
@@ -13,8 +13,6 @@ describe 'sslcertificate', :type => :define do
     } }
 
     it { should contain_exec('Install-testCert-SSLCert').with(
-      'command'  => 'template("sslcertificate/import.ps1.erb")',
-      'onlyif'   => 'template("sslcertificate/inspect.ps1.erb")',
       'provider' => 'powershell'
     )}
 


### PR DESCRIPTION
Importing the powershell templates directly from the "exec" instead of using files to store the powershell scripts which might contain the export password in clear text.